### PR TITLE
Faster check_install()

### DIFF
--- a/lib/Module/Load/Conditional.pm
+++ b/lib/Module/Load/Conditional.pm
@@ -252,7 +252,8 @@ sub check_install {
             if( $FIND_VERSION ) {
 
                 my $in_pod = 0;
-                while ( my $line = <$fh> ) {
+                my $line;
+                while ( $line = <$fh> ) {
 
                     ### #24062: "Problem with CPANPLUS 0.076 misidentifying
                     ### versions after installing Text::NSP 1.03" where a


### PR DESCRIPTION
These three small commits make Module::Load::Conditional::check_install() do its job 30% faster for a typical module.

Since check_install() accounts for most of the time spent while CPANPLUS looks for modules to update, this helps making the "o" command run faster. On a medium-sized perl tree, I see a 10% gain. For a freshly-installed perl tree, the gains are negligible.

Vincent.
